### PR TITLE
Refactor tests and options expectations

### DIFF
--- a/test/app-a/index.js
+++ b/test/app-a/index.js
@@ -1,5 +1,6 @@
 module.exports = (function() {
   require('lib-a1');
+  require('lib-ab1');
   require('lib-b1');
   require('lib-c1');
 })();

--- a/test/app-a/node_modules/lib-ab1/index.js
+++ b/test/app-a/node_modules/lib-ab1/index.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+  libs.push('lib-ab-1.0.0');
+})();

--- a/test/app-a/node_modules/lib-ab1/package.json
+++ b/test/app-a/node_modules/lib-ab1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-ab",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/app-a/node_modules/lib-b1/index.js
+++ b/test/app-a/node_modules/lib-b1/index.js
@@ -1,4 +1,5 @@
 module.exports = (function() {
-  require('lib-a2');
+  require('lib-a1');
+  require('lib-ab2');
   libs.push('lib-b-1.0.0');
 })();

--- a/test/app-a/node_modules/lib-b1/node_modules/lib-a1/index.js
+++ b/test/app-a/node_modules/lib-b1/node_modules/lib-a1/index.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+  libs.push('lib-a-1.0.0');
+})();

--- a/test/app-a/node_modules/lib-b1/node_modules/lib-a1/package.json
+++ b/test/app-a/node_modules/lib-b1/node_modules/lib-a1/package.json
@@ -1,5 +1,5 @@
 {
   "name": "lib-a",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "main": "index.js"
 }

--- a/test/app-a/node_modules/lib-b1/node_modules/lib-ab2/index.js
+++ b/test/app-a/node_modules/lib-b1/node_modules/lib-ab2/index.js
@@ -1,3 +1,3 @@
 module.exports = (function() {
-  libs.push('lib-a-2.0.0');
+  libs.push('lib-ab-2.0.0');
 })();

--- a/test/app-a/node_modules/lib-b1/node_modules/lib-ab2/package.json
+++ b/test/app-a/node_modules/lib-b1/node_modules/lib-ab2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-ab",
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,105 @@
 var expect = require('chai').expect;
 var browserify = require('browserify');
-var resolution = require('../index');
+var resolutions = require('../index');
 
 describe('when bundling app-a', function() {
-  var allLibs = ['lib-a-1.0.0', 'lib-a-2.0.0', 'lib-b-1.0.0', 'lib-b-2.0.0', 'lib-c-1.0.0'];
+
+  // Bundle expectations
+  // --------------------------
+  var expectedBundledLibs = {};
+
+  expectedBundledLibs.vanilla = [
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-ab-2.0.0',
+    'lib-b-1.0.0',
+    'lib-b-2.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  expectedBundledLibs['lib-a'] = expectedBundledLibs.vanilla;
+
+  expectedBundledLibs['lib-ab'] = [
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-b-1.0.0',
+    'lib-b-2.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  expectedBundledLibs['lib-ab,lib-b'] = [
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-b-1.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  expectedBundledLibs['*'] = expectedBundledLibs['lib-ab,lib-b'];
+
+  // Execution expectations
+  // --------------------------
+  var expectedExecutedLibs = {};
+
+  expectedExecutedLibs.vanilla = expectedBundledLibs.vanilla.concat([
+    'lib-a-1.0.0'
+  ]).sort();
+
+  expectedExecutedLibs['lib-a'] = expectedBundledLibs['lib-a'];
+
+  expectedExecutedLibs['lib-ab'] = [
+    'lib-a-1.0.0',
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-b-1.0.0',
+    'lib-b-2.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  expectedExecutedLibs['lib-ab,lib-b'] = [
+    'lib-a-1.0.0',
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-b-1.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  expectedExecutedLibs['*'] = [
+    'lib-a-1.0.0',
+    'lib-ab-1.0.0',
+    'lib-b-1.0.0',
+    'lib-c-1.0.0'
+  ].sort();
+
+  // Test helpers
+  // --------------------------
   var bundler;
 
+  function getBundledLibs(bundleString) {
+    var bundled = [];
+    var regex = /libs\.push\('(lib-.+)'\)/g;
+    var matches;
+
+    /* jshint -W084 */
+    while (matches = regex.exec(bundleString)) {
+      bundled.push(matches[1]);
+    }
+
+    return bundled;
+    /* jshint +W084 */
+  }
+
+  function bundleCallback(testFunc) {
+    return function(err, buf) {
+      var bufferString = buf.toString();
+      var bundledLibs = getBundledLibs(bufferString);
+      eval(bufferString);
+
+      return testFunc(bundledLibs);
+    };
+  }
+
+  // Tests
+  // --------------------------
   beforeEach(function() {
     libs = [];
     bundler = browserify({
@@ -14,58 +108,101 @@ describe('when bundling app-a', function() {
   });
 
   describe('using vanilla browserify', function() {
-    it('only dedupes identical sources', function(done) {
+    it('dedupes identical sources', function(done) {
       bundler
-        .bundle(function(err, buf) {
-          eval(buf.toString());
-          expect(libs).to.eql(allLibs);
+        .bundle(bundleCallback(function(bundledLibs) {
+          expect(bundledLibs.sort()).to.eql(expectedBundledLibs.vanilla);
           done();
-        });
+        }));
+    });
+
+    it('executes deduped sources', function(done) {
+      bundler
+        .bundle(bundleCallback(function() {
+          expect(libs.sort()).to.eql(expectedExecutedLibs.vanilla);
+          done();
+        }));
     });
   });
 
-  describe('using browserify-resolution', function() {
+  describe('using browserify-resolutions', function() {
     describe('and not passing options', function() {
       it('is vanilla dedupe', function(done) {
         bundler
-          .plugin(resolution, ['lib-z'])
-          .bundle(function(err, buf) {
-            eval(buf.toString());
-            expect(libs).to.eql(allLibs);
+          .plugin(resolutions)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs.vanilla);
+            expect(libs.sort()).to.eql(expectedExecutedLibs.vanilla);
             done();
-          });
+          }));
       });
     });
 
-    describe('and passing options', function() {
-      it('dedupes a matching package name', function(done) {
+    describe('and passing empty array', function() {
+      it('is vanilla dedupe', function(done) {
         bundler
-          .plugin(resolution, ['lib-a'])
-          .bundle(function(err, buf) {
-            eval(buf.toString());
-            expect(libs).to.eql(['lib-a-1.0.0', 'lib-b-1.0.0', 'lib-b-2.0.0', 'lib-c-1.0.0']);
+          .plugin(resolutions, [])
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs.vanilla);
+            expect(libs.sort()).to.eql(expectedExecutedLibs.vanilla);
             done();
-          });
+          }));
       });
+    });
 
-      it('dedupes multiple package names', function(done) {
+    describe('and passing a matching package name', function() {
+      it('bundles and executes the matching package once', function(done) {
+        var options = ['lib-ab'];
+
         bundler
-          .plugin(resolution, ['lib-a', 'lib-b'])
-          .bundle(function(err, buf) {
-            eval(buf.toString());
-            expect(libs).to.eql(['lib-a-1.0.0', 'lib-b-1.0.0', 'lib-c-1.0.0']);
+          .plugin(resolutions, options)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options.toString()]);
+            expect(libs.sort()).to.eql(expectedExecutedLibs[options.toString()]);
             done();
-          });
+          }));
       });
+    });
 
-      it('dedupes all package names if passed *', function(done) {
+    describe('and passing multiple matching package names', function() {
+      it('bundles and executes the matching packages once', function(done) {
+        var options = ['lib-ab', 'lib-b'];
+
         bundler
-          .plugin(resolution, '*')
-          .bundle(function(err, buf) {
-            eval(buf.toString());
-            expect(libs).to.eql(['lib-a-1.0.0', 'lib-b-1.0.0', 'lib-c-1.0.0']);
+          .plugin(resolutions, options)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options.join(',')]);
+            expect(libs.sort()).to.eql(expectedExecutedLibs[options.join(',')]);
             done();
-          });
+          }));
+      });
+    });
+
+    describe('and passing *', function() {
+      it('bundles and executes all packages once', function(done) {
+        var options = '*';
+
+        bundler
+          .plugin(resolutions, options)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options]);
+            expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
+            done();
+          }));
+      });
+    });
+
+    describe('and passing a matching package name that is a subset of another', function() {
+      it('dedupes only the matching package name, not the superset', function(done) {
+        var options = ['lib-a'];
+
+        bundler
+          .plugin(resolutions, options)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options]);
+            expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
+            done();
+          }));
       });
     });
   });


### PR DESCRIPTION
- Differentiate between bundled and executed expectations in tests. Unearthed a bug where deduped libs where always being prevented from executing multiple times, even if no options were passed.
- Fix above mentioned bug.
- Create a test to cover scenario explained in #2. To fix, convert all options to an array except for special case `*`. Possibly throw errors on unexpected options in the future.
