### PR TITLE
Bug/resolved deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },  
   "keywords": [
     "browserify",
+    "browserify-plugin",
     "resolutions",
     "dedupe",
     "duplication"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "through2": "^0.6.5"
   },
   "devDependencies": {
-    "browserify": "^9.0.8",
+    "browserify": "^10.0.0",
     "chai": "^2.2.0",
     "mocha": "^2.2.4"
   }

--- a/test/app-a-test.js
+++ b/test/app-a-test.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var browserify = require('browserify');
 var resolutions = require('../index');
+var bundleCallback = require('./utils').bundleCallback;
 
 describe('when bundling app-a', function() {
 
@@ -70,36 +71,10 @@ describe('when bundling app-a', function() {
     'lib-c-1.0.0'
   ].sort();
 
-  // Test helpers
+  // Tests
   // --------------------------
   var bundler;
 
-  function getBundledLibs(bundleString) {
-    var bundled = [];
-    var regex = /libs\.push\('(lib-.+)'\)/g;
-    var matches;
-
-    /* jshint -W084 */
-    while (matches = regex.exec(bundleString)) {
-      bundled.push(matches[1]);
-    }
-
-    return bundled;
-    /* jshint +W084 */
-  }
-
-  function bundleCallback(testFunc) {
-    return function(err, buf) {
-      var bufferString = buf.toString();
-      var bundledLibs = getBundledLibs(bufferString);
-      eval(bufferString);
-
-      return testFunc(bundledLibs);
-    };
-  }
-
-  // Tests
-  // --------------------------
   beforeEach(function() {
     libs = [];
     bundler = browserify({

--- a/test/app-b-test.js
+++ b/test/app-b-test.js
@@ -1,0 +1,52 @@
+var expect = require('chai').expect;
+var browserify = require('browserify');
+var resolutions = require('../index');
+var bundleCallback = require('./utils').bundleCallback;
+
+describe('when bundling app-b', function() {
+
+  // Bundle expectations
+  // --------------------------
+  var expectedBundledLibs = {};
+
+  expectedBundledLibs['lib-a'] = [
+    'lib-a-1.0.0',
+    'lib-b-1.0.0'
+  ].sort();
+
+  // Execution expectations
+  // --------------------------
+  var expectedExecutedLibs = {};
+
+  expectedExecutedLibs['lib-a'] = [
+    'lib-a-1.0.0',
+    'lib-b-1.0.0'
+  ].sort();
+
+  // Tests
+  // --------------------------
+  var bundler;
+
+  beforeEach(function() {
+    libs = [];
+    bundler = browserify({
+      entries: ['./test/app-b']
+    });
+  });
+
+  describe('using browserify-resolutions', function() {
+    describe('and passing matching package which main is a CJS "wrapper" (ala Angular)', function() {
+      it('dedupes both the wrapper and the source', function(done) {
+        var options = ['lib-a'];
+
+        bundler
+          .plugin(resolutions, options)
+          .bundle(bundleCallback(function(bundledLibs) {
+            expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options]);
+            expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
+            done();
+          }));
+      });
+    });
+  });
+});

--- a/test/app-b/index.js
+++ b/test/app-b/index.js
@@ -1,0 +1,4 @@
+module.exports = (function() {
+  require('lib-a1');
+  require('lib-b1');
+})();

--- a/test/app-b/node_modules/lib-a1/index.js
+++ b/test/app-b/node_modules/lib-a1/index.js
@@ -1,0 +1,1 @@
+require('./source');

--- a/test/app-b/node_modules/lib-a1/package.json
+++ b/test/app-b/node_modules/lib-a1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/app-b/node_modules/lib-a1/source.js
+++ b/test/app-b/node_modules/lib-a1/source.js
@@ -1,0 +1,3 @@
+(function() {
+  libs.push('lib-a-1.0.0');
+})();

--- a/test/app-b/node_modules/lib-b1/index.js
+++ b/test/app-b/node_modules/lib-b1/index.js
@@ -1,0 +1,4 @@
+module.exports = (function() {
+  require('lib-a2');
+  libs.push('lib-b-1.0.0');
+})();

--- a/test/app-b/node_modules/lib-b1/node_modules/lib-a2/index.js
+++ b/test/app-b/node_modules/lib-b1/node_modules/lib-a2/index.js
@@ -1,0 +1,1 @@
+require('./source');

--- a/test/app-b/node_modules/lib-b1/node_modules/lib-a2/package.json
+++ b/test/app-b/node_modules/lib-b1/node_modules/lib-a2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-a",
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/test/app-b/node_modules/lib-b1/node_modules/lib-a2/source.js
+++ b/test/app-b/node_modules/lib-b1/node_modules/lib-a2/source.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+  libs.push('lib-a-2.0.0');
+})();

--- a/test/app-b/node_modules/lib-b1/package.json
+++ b/test/app-b/node_modules/lib-b1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-b",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/app-b/package.json
+++ b/test/app-b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,28 @@
+module.exports = {
+  bundleCallback: bundleCallback
+};
+
+function getBundledLibs(bundleString) {
+  var bundled = [];
+  var regex = /libs\.push\('(lib-.+)'\)/g;
+  var matches;
+
+  /* jshint -W084 */
+  while (matches = regex.exec(bundleString)) {
+    bundled.push(matches[1]);
+  }
+
+  return bundled;
+  /* jshint +W084 */
+}
+
+function bundleCallback(testFunc) {
+  return function(err, buf) {
+    var bufferString = buf.toString();
+    var bundledLibs = getBundledLibs(bufferString);
+    eval(bufferString);
+
+    return testFunc(bundledLibs);
+  };
+}
+


### PR DESCRIPTION
After fixing caching in the last update, limiting it to what was passed in the options instead of greedly applying itself to everything, it revealed a problem that had previously been masked: caching wasn’t being applied to the source file in the “Angular CJS wrapper” scenario (when the main file acts as a wrapper for the non CJS source, requiring it).

We fix it by applying cache if resolved dupe's (Angular's index.js) dependencies (angular.js) are dupes too.
