### PR TITLE
Add failing test case for deduping non-main requires

### DIFF
--- a/test/non-main-require-test.js
+++ b/test/non-main-require-test.js
@@ -1,0 +1,34 @@
+var expect = require('chai').expect;
+var browserify = require('browserify');
+var resolution = require('../index');
+var bundleCallback = require('./utils').bundleCallback;
+
+describe('when bundling app that does non-main requires', function() {
+  var bundler;
+
+  beforeEach(function() {
+    libs = [];
+    bundler = browserify({
+      entries: ['./test/non-main-require']
+    });
+  });
+
+  describe('using vanilla browserify', function() {
+    it('only dedupes identical sources', function(done) {
+      bundler
+        .bundle(bundleCallback(function (bundledLibs) {
+          expect(bundledLibs.sort()).to.eql(['lib-a-1.0.0', 'lib-common-1.0.0']);
+          done();
+        }));
+    });
+  });
+
+  it('dedupes package names', function(done) {
+    bundler
+      .plugin(resolution, ['lib-common'])
+      .bundle(bundleCallback(function (bundledLibs) {
+        expect(bundledLibs).to.eql(['lib-a-1.0.0', 'lib-common-1.0.0']);
+        done();
+      }));
+  });
+});

--- a/test/non-main-require/index.js
+++ b/test/non-main-require/index.js
@@ -1,0 +1,4 @@
+module.exports = (function() {
+  require('lib-a1');
+  require('lib-common/non-main');
+})();

--- a/test/non-main-require/node_modules/lib-a1/index.js
+++ b/test/non-main-require/node_modules/lib-a1/index.js
@@ -1,0 +1,4 @@
+module.exports = (function() {
+  require('lib-common/non-main');
+  libs.push('lib-a-1.0.0');
+})();

--- a/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/index.js
+++ b/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/index.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+  libs.push('lib-common-1.0.0');
+})();

--- a/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/non-main.js
+++ b/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/non-main.js
@@ -1,0 +1,1 @@
+module.exports = require('./index');

--- a/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/package.json
+++ b/test/non-main-require/node_modules/lib-a1/node_modules/lib-common/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-common",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/non-main-require/node_modules/lib-a1/package.json
+++ b/test/non-main-require/node_modules/lib-a1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/non-main-require/node_modules/lib-common/index.js
+++ b/test/non-main-require/node_modules/lib-common/index.js
@@ -1,0 +1,3 @@
+module.exports = (function() {
+  libs.push('lib-common-1.0.0');
+})();

--- a/test/non-main-require/node_modules/lib-common/non-main.js
+++ b/test/non-main-require/node_modules/lib-common/non-main.js
@@ -1,0 +1,1 @@
+module.exports = require('./index');

--- a/test/non-main-require/node_modules/lib-common/package.json
+++ b/test/non-main-require/node_modules/lib-common/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib-common",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/non-main-require/package.json
+++ b/test/non-main-require/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "non-main-require",
+  "version": "1.0.0",
+  "main": "index.js"
+}


### PR DESCRIPTION
I think I may have found an issue with deduping when one of the packages being deduped is required using a file other than the "main" package file. In my test case (non-main-require.js), I have a lib (lib-common) that is required in two places using `require('lib-common/non-main')`. `lib-common` does not appear in the actual result at all, when I expected it to be deduped and only appear once.
