### PR TITLE
Bug/bundle twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 var _         = require('lodash');
 var through   = require('through2');
+var join      = require('path').join;
 
 // Exports
 // ________________________
 
 exports = module.exports =
 
+  /**
+   * Entry point for the two plugins that comprise browserify-resolutions.
+   * See below for detailed write-ups on each.
+   *
+   * @param  {Object} bundler Browserify instance.
+   * @param  {Array/String} packageMatcher List of modules to resolve a version for or
+   *                                       "*" to attempt to resolve all.
+   * @return {Object} Browserify instance.
+   */
   function(bundler, packageMatcher) {
     packageMatcher = parseOptions(packageMatcher);
 
@@ -64,8 +74,6 @@ exports = module.exports =
    * is different between all versions and not deduped.
    *
    * Note II: This method otherwise mimics Browserify's own to make sure nothing breaks.
-   *
-   * @param  {Object} bundler Browserify instance.
    */
   function dedupeCache(bundler, options) {
     var resolved = options.resolved;
@@ -116,9 +124,6 @@ exports = module.exports =
    * Currently, the given version is the first one that Browserify parses. Typically, that is the desired one.
    * TODO: Allow choosing a specific module version to bundle.
    *
-   * @param  {Object} bundler Browserify instance.
-   * @param  {Array/String}  options.packageMatcher List of modules to resolve a version for or
-   *                                                "*" to attempt to resolve all.
    */
   function dedupeResolutions(bundler, options) {
     var modules = {};
@@ -129,22 +134,40 @@ exports = module.exports =
     var resolved        = options.resolved;
     var deduped         = options.deduped;
     var packageMatcher  = options.packageMatcher;
+    var packageCache    = bundler._options.packageCache;
 
-    bundler.pipeline.on('package', function(package) {
-      var name = package.name;
+    bundler.pipeline.on('package', packageListener);
 
-      // Does this package represent the module we're trying to resolve a version for?
-      if (name && (packageMatcher.indexOf(name) !== -1 || packageMatcher === '*')) {
-        // Assume (safely?) that the first file emitted after a package is that package's `main`.
-        bundler.pipeline.once('file', function(file) {
-          modules[name] = modules[name] || [];
-          modules[name].push(file);
-
-          // Flag to grab these dependencies when available in our 'deps' stream handler.
-          deps[file] = true;
-        });
+    function packageListener(package) {
+      if (isResolvablePackage(package)) {
+        if (isCachedPackage(package)) {
+          groupByPackage(package, join(package.__dirname, package.main));
+        } else {
+          // Assuming first processed after this package is its `main`. Intead of just parsing out
+          // `main` ourselves, let `module-deps` handle it since it may be a custom field.
+          bundler.pipeline.once('file', _.partial(groupByPackage, package));
+        }
       }
-    });
+
+      function isResolvablePackage(package) {
+        return package.main && package.name &&
+          (packageMatcher.indexOf(package.name) !== -1 || packageMatcher === '*');
+      }
+
+      function isCachedPackage(package) {
+        var packagePath = join(package.__dirname, 'package.json');
+        return packageCache && packageCache.hasOwnProperty(packagePath);
+      }
+
+      // Group all `main`s by their package name.
+      function groupByPackage(package, file) {
+        modules[package.name] = modules[package.name] || [];
+        modules[package.name].push(file);
+
+        // Flag to grab these dependencies when available in our 'deps' stream handler.
+        deps[file] = true;
+      }
+    }
 
     bundler.pipeline.get('deps')
       .push(through.obj(
@@ -206,7 +229,11 @@ exports = module.exports =
         },
         function end(cb) {
           // Array of ids for files that we're treating as originals.
-          var originals = _.values(deduped).concat(_.keys(resolved));
+          var originals = _(deduped)
+            .values()
+            .concat(_.keys(resolved))
+            .unique()
+            .value();
 
           _.each(rows, function(row) {
             var file = row.file;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "browserify": "^10.0.0",
     "chai": "^2.2.0",
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.4",
+    "watchify": "^3.2.2"
   }
 }

--- a/test/app-a-test.js
+++ b/test/app-a-test.js
@@ -168,9 +168,9 @@ describe('when bundling app-a', function() {
     });
 
     describe('and passing a matching package name that is a subset of another', function() {
-      it('dedupes only the matching package name, not the superset', function(done) {
-        var options = ['lib-a'];
+      var options = ['lib-a'];
 
+      it('dedupes only the matching package name, not the superset', function(done) {
         bundler
           .plugin(resolutions, options)
           .bundle(bundleCallback(function(bundledLibs) {
@@ -178,6 +178,23 @@ describe('when bundling app-a', function() {
             expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
             done();
           }));
+      });
+
+      // Test to verify that calling bundle() twice consecutively works, in general.
+      // No specific reason its mirroring the test above, just piggy-backing off a verified result.
+      describe('and calling bundle a second time', function() {
+        it('produces the same bundle as the first time', function(done) {
+          bundler
+            .plugin(resolutions, options)
+            .bundle();
+
+          bundler
+            .bundle(bundleCallback(function(bundledLibs) {
+              expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options]);
+              expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
+              done();
+            }));
+        });
       });
     });
   });

--- a/test/app-a-test.js
+++ b/test/app-a-test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect;
 var browserify = require('browserify');
+var watchify = require('watchify');
 var resolutions = require('../index');
 var bundleCallback = require('./utils').bundleCallback;
 
@@ -154,9 +155,9 @@ describe('when bundling app-a', function() {
     });
 
     describe('and passing *', function() {
-      it('bundles and executes all packages once', function(done) {
-        var options = '*';
+      var options = '*';
 
+      it('bundles and executes all packages once', function(done) {
         bundler
           .plugin(resolutions, options)
           .bundle(bundleCallback(function(bundledLibs) {
@@ -164,6 +165,31 @@ describe('when bundling app-a', function() {
             expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
             done();
           }));
+      });
+
+      // Integration test to verify that the plugin is watchify-compatible.
+      // Piggy-backing off of the '*'-option test b/c its more likely to expose flaws.
+      //
+      // TODO: Fails randomly due to the non-deterministic order in which `moduleDeps`'s' `package` event
+      // is dispatching cached packages. As browserify-resolutions currently uses the first package it
+      // comes across as the "original" and marks all other dupes, it makes the result non-deterministic as well.
+      describe('and is rebundled with watchify', function() {
+        it('produces the same bundle as the first time', function(done) {
+          bundler._options.cache = {};
+          bundler._options.packageCache = {};
+          bundler = watchify(bundler);
+
+          bundler
+            .plugin(resolutions, options)
+            .bundle(function() {
+              bundler
+                .bundle(bundleCallback(function(bundledLibs) {
+                  expect(bundledLibs.sort()).to.eql(expectedBundledLibs[options]);
+                  expect(libs.sort()).to.eql(expectedExecutedLibs[options]);
+                  done();
+                }));
+            });
+        });
       });
     });
 


### PR DESCRIPTION
- Add 2 failing tests:
  - Calling bundle() twice in a row produced unexpected results. The second call should produce the same bundle as the first.
  - The plugin was not compatible with `watchify` >= 3.0.0, getting thrown off by its `packageCache`.
- Make fixes for above to tests. 
  - **Big caveat**: The `watchify` test fails randomly due to how `packageCache` appears to cause `package` events to be triggered non-deterministically. TODO
